### PR TITLE
Fix Response Error Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Web: **Not implemented**
 ## Install
 
 ```shell
-npx expo install expo-http-server
+npx expo install @kccd/expo-http-server
 ```
 
 ## Example

--- a/ios/ExpoHttpServerModule.swift
+++ b/ios/ExpoHttpServerModule.swift
@@ -154,6 +154,8 @@ extension CRHTTPMethod {
             return "PUT"
         case .delete:
             return "DELETE"
+        case .options:
+            return "OPTIONS"
         default:
             return "GET"
         }
@@ -168,6 +170,8 @@ extension CRHTTPMethod {
             httpMethod = .put
         case "DELETE":
             httpMethod = .delete
+        case "OPTIONS":
+            httpMethod = .options
         default:
             httpMethod = .get
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kccd/expo-http-server",
-	"version": "0.1.13",
+	"version": "0.1.14",
 	"description": "A simple HTTP server expo module (iOS/Android)",
 	"main": "build/index.js",
 	"types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "expo-http-server",
+	"name": "@kccd/expo-http-server",
 	"version": "0.1.13",
 	"description": "A simple HTTP server expo module (iOS/Android)",
 	"main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "expo-http-server",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"description": "A simple HTTP server expo module (iOS/Android)",
 	"main": "build/index.js",
 	"types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
 		"clean": "expo-module clean",
 		"lint": "expo-module lint",
 		"test": "expo-module test",
-		"prepare": "expo-module prepare",
-		"prepublishOnly": "expo-module prepublishOnly",
-		"expo-module": "expo-module",
 		"open:ios": "open -a \"Xcode\" example/ios",
 		"open:android": "open -a \"Android Studio\" example/android"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kccd/expo-http-server",
-	"version": "0.1.14",
+	"version": "0.1.15",
 	"description": "A simple HTTP server expo module (iOS/Android)",
 	"main": "build/index.js",
 	"types": "build/index.d.ts",
@@ -9,6 +9,9 @@
 		"clean": "expo-module clean",
 		"lint": "expo-module lint",
 		"test": "expo-module test",
+		"prepare": "expo-module prepare",
+		"prepublishOnly": "expo-module prepublishOnly",
+		"expo-module": "expo-module",
 		"open:ios": "open -a \"Xcode\" example/ios",
 		"open:android": "open -a \"Android Studio\" example/android"
 	},

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
 		"expo-http-server",
 		"ExpoHttpServer"
 	],
-	"repository": "https://github.com/simonsturge/expo-http-server",
+	"repository": "https://github.com/kccd/expo-http-server",
 	"bugs": {
-		"url": "https://github.com/simonsturge/expo-http-server/issues"
+		"url": "https://github.com/kccd/expo-http-server/issues"
 	},
 	"author": "Simon <development@simonsturge.com> (https://github.com/simonsturge)",
 	"license": "MIT",
-	"homepage": "https://github.com/simonsturge/expo-http-server#readme",
+	"homepage": "https://github.com/kccd/expo-http-server#readme",
 	"dependencies": {},
 	"devDependencies": {
 		"@types/react": "^18.0.25",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export interface StatusEvent {
 
 export interface RequestEvent {
   uuid: string;
-  requestId: string;
   method: string;
   path: string;
   body: string;
@@ -42,12 +41,12 @@ export interface Callback {
   callback: (request: RequestEvent) => Promise<Response>;
 }
 
-export const start = async () => {
+export const start = () => {
   emitter.addListener<RequestEvent>("onRequest", async (event) => {
     const responseHandler = requestCallbacks.find((c) => c.uuid === event.uuid);
     if (!responseHandler) {
       ExpoHttpServerModule.respond(
-        event.requestId,
+        event.uuid,
         404,
         "Not Found",
         "application/json",
@@ -58,7 +57,7 @@ export const start = async () => {
     }
     const response = await responseHandler.callback(event);
     ExpoHttpServerModule.respond(
-      event.requestId,
+      event.uuid,
       response.statusCode || 200,
       response.statusDescription || "OK",
       response.contentType || "application/json",
@@ -66,7 +65,7 @@ export const start = async () => {
       response.body || "{}",
     );
   });
-  return ExpoHttpServerModule.start() as string;
+  ExpoHttpServerModule.start();
 };
 
 export const route = (
@@ -84,7 +83,7 @@ export const route = (
   ExpoHttpServerModule.route(path, method, uuid);
 };
 
-export const setup = async (
+export const setup = (
   port: number,
   onStatusUpdate?: (event: StatusEvent) => void,
 ) => {
@@ -93,7 +92,7 @@ export const setup = async (
       onStatusUpdate(event);
     });
   }
-  return ExpoHttpServerModule.setup(port) as string;
+  ExpoHttpServerModule.setup(port);
 };
 
-export const stop = async () => ExpoHttpServerModule.stop() as string;
+export const stop = () => ExpoHttpServerModule.stop();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export interface StatusEvent {
 
 export interface RequestEvent {
   uuid: string;
+  requestId: string;
   method: string;
   path: string;
   body: string;
@@ -46,7 +47,7 @@ export const start = () => {
     const responseHandler = requestCallbacks.find((c) => c.uuid === event.uuid);
     if (!responseHandler) {
       ExpoHttpServerModule.respond(
-        event.uuid,
+        event.requestId,
         404,
         "Not Found",
         "application/json",
@@ -57,7 +58,7 @@ export const start = () => {
     }
     const response = await responseHandler.callback(event);
     ExpoHttpServerModule.respond(
-      event.uuid,
+      event.requestId,
       response.statusCode || 200,
       response.statusDescription || "OK",
       response.contentType || "application/json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export interface StatusEvent {
 
 export interface RequestEvent {
   uuid: string;
+  requestId: string;
   method: string;
   path: string;
   body: string;
@@ -41,12 +42,12 @@ export interface Callback {
   callback: (request: RequestEvent) => Promise<Response>;
 }
 
-export const start = () => {
+export const start = async () => {
   emitter.addListener<RequestEvent>("onRequest", async (event) => {
     const responseHandler = requestCallbacks.find((c) => c.uuid === event.uuid);
     if (!responseHandler) {
       ExpoHttpServerModule.respond(
-        event.uuid,
+        event.requestId,
         404,
         "Not Found",
         "application/json",
@@ -57,7 +58,7 @@ export const start = () => {
     }
     const response = await responseHandler.callback(event);
     ExpoHttpServerModule.respond(
-      event.uuid,
+      event.requestId,
       response.statusCode || 200,
       response.statusDescription || "OK",
       response.contentType || "application/json",
@@ -65,7 +66,7 @@ export const start = () => {
       response.body || "{}",
     );
   });
-  ExpoHttpServerModule.start();
+  return ExpoHttpServerModule.start() as string;
 };
 
 export const route = (
@@ -83,7 +84,7 @@ export const route = (
   ExpoHttpServerModule.route(path, method, uuid);
 };
 
-export const setup = (
+export const setup = async (
   port: number,
   onStatusUpdate?: (event: StatusEvent) => void,
 ) => {
@@ -92,7 +93,7 @@ export const setup = (
       onStatusUpdate(event);
     });
   }
-  ExpoHttpServerModule.setup(port);
+  return ExpoHttpServerModule.setup(port) as string;
 };
 
-export const stop = () => ExpoHttpServerModule.stop();
+export const stop = async () => ExpoHttpServerModule.stop() as string;


### PR DESCRIPTION
### Phenomenon:
When making two requests to the same route in quick succession, the response of the first request might be sent to the second request.

### Cause:
In the Android/iOS code, upon receiving a request, the state information of the request is stored using a key-value pair, where the key is the route's UUID. Therefore, in the same route, the state of the previous request might be overwritten by the state of the next request, leading to a mix-up in the response data.

### Solution:
Assign a unique ID to each request and use this ID as the key when storing the request state.
Additionally, added support for the OPTIONS request method for iOS.
